### PR TITLE
Add preview overlay for dashboard builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/node_modules
+/dist
+/out-tsc
+/.angular/cache
+/.angular
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# dashboard
+# Dashboard Builder
+
+Aplicação Angular que materializa o construtor de dashboards solicitado, com layout inspirado no Looker Studio e identidade visual da plataforma Solução.
+
+## Requisitos
+- Node.js 20+
+- npm 9+
+- Angular CLI (opcional para rodar comandos `ng` globalmente)
+
+## Como executar
+```bash
+npm install
+npm start
+```
+O comando `npm start` inicia o servidor de desenvolvimento em `http://localhost:4200/`.
+
+Para gerar uma build de produção utilize:
+```bash
+npm run build
+```
+
+## Estrutura de pastas
+- `src/app` – componentes, serviços e modelos do construtor.
+- `src/assets` – arquivos estáticos.
+- `docs/dashboard-builder.md` – documentação conceitual original.
+
+## Principais componentes
+- `app.component` – shell principal com painel, canvas e inspector.
+- `builder-state.service` – gerencia estado de páginas, componentes e fontes de dados.
+- `component-library` – catálogo drag and drop de componentes.
+- `canvas` – área de edição responsiva com suporte a drag-and-drop.
+- `inspector` – formulário dinâmico para edição de propriedades.
+- `data-source-drawer` – gestão de fontes de dados em overlay lateral.
+- `preview-overlay` – pré-visualização em tela cheia com troca de página e dispositivo.

--- a/angular.json
+++ b/angular.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "dashboard-builder-app": {
+      "projectType": "application",
+      "schematics": {},
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/dashboard-builder-app",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": ["zone.js"],
+            "tsConfig": "tsconfig.app.json",
+            "inlineStyleLanguage": "scss",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "500kb",
+                  "maximumError": "1mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "2kb",
+                  "maximumError": "4kb"
+                }
+              ],
+              "outputHashing": "all"
+            },
+            "development": {
+              "buildOptimizer": false,
+              "optimization": false,
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "sourceMap": true
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "configurations": {
+            "production": {
+              "browserTarget": "dashboard-builder-app:build:production"
+            },
+            "development": {
+              "browserTarget": "dashboard-builder-app:build:development"
+            }
+          },
+          "defaultConfiguration": "development"
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "options": {
+            "browserTarget": "dashboard-builder-app:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "polyfills": ["zone.js", "zone.js/testing"],
+            "tsConfig": "tsconfig.spec.json",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
+            "scripts": []
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "dashboard-builder-app"
+}

--- a/docs/dashboard-builder.md
+++ b/docs/dashboard-builder.md
@@ -1,0 +1,105 @@
+# Construtor de Dashboards Integrado à Plataforma
+
+## Visão Geral
+O construtor de dashboards deve replicar os conceitos centrais do Looker Studio (Google), mas traduzindo-os para a linguagem visual da plataforma Solução demonstrada na imagem fornecida. O objetivo é permitir que analistas e gestores montem painéis flexíveis, com múltiplas páginas e fontes de dados variadas, aproveitando a navegação superior, o menu lateral iconográfico e a identidade cromática já existente (azul-marinho predominante, ícones claros, cartões com cantos arredondados e leve sombra).
+
+### Objetivos Principais
+- Oferecer experiência de edição WYSIWYG com drag and drop.
+- Permitir organização em projetos/pastas, páginas e seções.
+- Habilitar criação e gerenciamento de fontes de dados reutilizáveis.
+- Garantir responsividade multi-dispositivo (conceitos inspirados no Analytics Studio da Sankhya).
+- Fornecer biblioteca rica de componentes (gráficos, tabelas, filtros, elementos visuais).
+
+## Layout Geral do Construtor
+
+| Região | Descrição |
+| --- | --- |
+| **Barra Superior (Header)** | Mantém o estilo já presente: fundo azul-marinho (#0D1B2A aprox.), logotipo à esquerda, breadcrumb central e ações à direita (Salvar, Publicar, Visualizar). Adiciona um seletor de "Projeto / Dashboard" e indicador de status (Rascunho, Publicado). |
+| **Menu Lateral** | Reaproveita ícones existentes e adiciona novas seções: "Biblioteca de Componentes", "Fontes de Dados", "Modelos" e "Configurações". Ícones com estilo lineal branco sobre fundo azul, com tooltip ao passar o mouse. |
+| **Painel Central (Canvas)** | Área de edição com fundo claro (#F5F7FA) e grid configurável (8px). Permite alternar entre visualizações Desktop, Tablet e Mobile (inspirado na aba Responsividade do Analytics Studio). |
+| **Painel Lateral Direito (Inspector)** | Surge ao selecionar um componente. Tabs: Propriedades, Dados, Estilo e Interações. Utiliza cartões brancos com sombra suave, tipografia consistente com a plataforma. |
+
+## Fluxos Essenciais
+
+1. **Criação de Projeto**
+   - Botão "Novo Dashboard" na home do módulo. Modal solicita nome, descrição, pasta/projeto e escolhe modelo em branco ou pré-configurado.
+   - Ao confirmar, usuário é direcionado ao construtor com uma página em branco e grid ativado.
+
+2. **Gestão de Páginas**
+   - Sidebar horizontal abaixo do header exibe tabs de páginas (similar ao Looker Studio). Permite duplicar, reordenar, ocultar ou definir como inicial.
+   - Suporta grupos de páginas para dashboards extensos.
+
+3. **Inserção de Componentes**
+   - Biblioteca apresenta blocos categorizados: Básicos (Texto, Imagem, Retângulo), Tabelas (Dinâmica, Resumo), Gráficos (Linha, Barra, Pizza, Séries temporais, Mapa), Filtros (Dropdown, Intervalo de datas, Segmentadores), Indicadores (KPI card, Gauge, Semáforo), Objetos avançados (Iframe, HTML customizado).
+   - Elementos arrastáveis para o canvas. Snap inteligente ao grid e guias de alinhamento.
+
+4. **Configuração de Dados**
+   - Aba "Fontes de Dados" no menu lateral abre gerenciador sobreposto (drawer). Usuário adiciona conexões (Banco SQL, API REST, CSV, ERP Sankhya, Google Sheets). 
+   - Cada fonte possui tela de autenticação, pré-visualização e definição de campos.
+   - Permite criar Views combinando fontes via joins e fórmulas (semelhante a Data Blending do Looker Studio).
+
+5. **Edição de Propriedades**
+   - Painel direito com campos contextuais. Ex.: para um gráfico de barras: seleção de métricas, dimensões, filtros, estilo (cores, bordas, tipografia). 
+   - Aba "Interações" permite criar ações de drill-down, navegar para outras páginas, aplicar filtros cruzados.
+
+6. **Visualização e Publicação**
+   - Botão "Visualizar" abre modo fullscreen sem ferramentas, mantendo header da plataforma.
+   - No protótipo implementado, essa ação apresenta um overlay imersivo com troca de páginas e dispositivos, simulando a visão final do dashboard.
+   - "Publicar" gera URL compartilhável interna, com controles de permissão (visualizador, editor, comentarista).
+
+## Regras de Responsividade
+Inspirado nas diretrizes do Analytics Studio:
+- Breakpoints principais: 1280px (desktop), 992px (tablet), 576px (mobile).
+- Layout base utiliza grid fluido com rearranjo automático (componentes podem ter configurações específicas por breakpoint).
+- Opção de "Auto Layout" para painéis: reorganiza componentes em colunas quando largura diminui.
+- Visualização de prévias por dispositivo no topo do canvas (ícones Desktop/Tablet/Mobile).
+- Propriedades responsivas: tamanhos percentuais, âncoras, comportamento de esconder/mostrar por dispositivo.
+
+## Biblioteca de Componentes (Resumo)
+
+| Categoria | Componentes |
+| --- | --- |
+| Indicadores | Cartão KPI, Cartão comparativo (variação vs período anterior), Indicador com faixa (min/máx). |
+| Gráficos | Barras, Linhas, Área, Pizza/Donut, Coluna empilhada, Mapa de calor, Geográfico, Série temporal, Waterfall, Funil. |
+| Tabelas | Tabela padrão, Tabela dinâmica (pivot), Tabela comparativa, Matriz. |
+| Filtros | Dropdown, Multi-select, Intervalo de datas, Botões, Segmentador tipo chips. |
+| Texto & Mídia | Texto rico, Títulos, Imagens, Ícones, Vídeo incorporado, Forma básica. |
+| Avançados | Iframe, Código HTML, Parâmetro calculado, Botões de ação, Scorecard conectado a meta. |
+
+## Gestão de Fontes de Dados
+- **Catálogo Global**: painel dedicado (no menu lateral) para registrar, editar e versionar fontes.
+- **Modelagem**: assistente de transformação com passos (Limpeza, Cálculo, Agrupamento). Suporta fórmulas semelhantes ao Looker Studio (funções agregadas, condicionais, manipulação de datas).
+- **Agendamento**: definição de atualização (tempo real, sob demanda, agendado). Notificações de falha por e-mail/alerta in-app.
+- **Governança**: permissões por perfil; logs de uso de cada fonte.
+
+## Funcionalidades Adicionais
+- **Histórico de versões**: timeline com restauração de estados anteriores.
+- **Comentários in-line**: modo de comentários colaborativos (balões fixados a componentes).
+- **Templates**: galeria com dashboards prontos (Financeiro, Comercial, Operacional) utilizando estética de cartões com sombras suaves, tipografia Montserrat/Roboto.
+- **Tema visual**: paletas pré-definidas (Solução, Neutro, Dark) e opção de personalização.
+- **Modo de Apresentação**: roda em fullscreen com navegação por setas, ocultando menus laterais.
+
+## Diretrizes de UI e Identidade
+- **Cores principais**: Azul-marinho (#0D1B2A), azul intermediário (#1B263B), cinza claro (#E0E6ED) e branco (#FFFFFF). Destaques em verde (#2EC4B6) para ações positivas e laranja (#FF9F1C) para alertas.
+- **Tipografia**: Usar família sem serifa já aplicada (ex.: Montserrat). Títulos 18-24px, textos 14-16px.
+- **Cartões**: Cantos arredondados (12px), sombra suave (0 4px 16px rgba(13, 27, 42, 0.08)).
+- **Ícones**: estilo lineal preenchido, mantendo consistência com menu atual.
+- **Feedbacks**: Toasts no canto superior direito (salvo com sucesso, erro de conexão).
+
+## Jornadas de Usuário
+1. **Analista monta dashboard do zero**: seleciona template em branco, conecta fonte ERP, adiciona gráficos, configura filtros e publica para diretoria.
+2. **Gestor ajusta painel existente**: duplica página de vendas, altera métricas e salva como nova versão.
+3. **Time financeiro cria modelo recorrente**: cadastra fonte de dados agendada, aplica transformações, salva como template reutilizável.
+
+## Requisitos Técnicos (alto nível)
+- Front-end em framework reativo (React/Vue) com suporte a canvas drag-and-drop (p. ex. GridLayout, InteractJS).
+- Motor de dados com camada de abstração para múltiplos conectores (REST, SQL, arquivos, Sankhya).
+- Armazenamento de metadados versionado (ex.: Firestore, Postgres) com JSON schema para layout.
+- API de renderização para exportação (PDF, imagem) e incorporação em outras áreas da plataforma.
+
+## Roadmap Inicial
+1. **MVP**: criação de dashboards com componentes básicos, conexão a fontes internas, publicação interna.
+2. **Iteração 2**: biblioteca ampliada, responsividade avançada, templates.
+3. **Iteração 3**: colaboração em tempo real, comentários, controle granular de permissões.
+4. **Iteração 4**: marketplace de componentes/templates, automações (alertas baseados em métricas).
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "dashboard-builder-app",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "watch": "ng build --watch --configuration development",
+    "test": "ng test"
+  },
+  "dependencies": {
+    "@angular/animations": "^17.3.0",
+    "@angular/common": "^17.3.0",
+    "@angular/compiler": "^17.3.0",
+    "@angular/core": "^17.3.0",
+    "@angular/forms": "^17.3.0",
+    "@angular/platform-browser": "^17.3.0",
+    "@angular/platform-browser-dynamic": "^17.3.0",
+    "@angular/router": "^17.3.0",
+    "@angular/cdk": "^17.3.0",
+    "rxjs": "^7.8.0",
+    "tslib": "^2.6.2",
+    "zone.js": "^0.14.4"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^17.3.0",
+    "@angular/cli": "^17.3.0",
+    "@angular/compiler-cli": "^17.3.0",
+    "@types/jasmine": "~5.1.0",
+    "jasmine-core": "~5.1.0",
+    "karma": "~6.4.0",
+    "karma-chrome-launcher": "~3.2.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "typescript": "~5.4.0"
+  }
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,0 +1,98 @@
+<div class="app-shell" *ngIf="(pages$ | async) as pages">
+  <app-header
+    [project]="project$ | async"
+    (toggleDataSources)="onToggleDataSources()"
+    (publish)="onPublish()"
+    (saveDraft)="onSaveDraft()"
+    (preview)="onPreview()"
+  ></app-header>
+
+  <div class="app-body">
+    <app-side-nav
+      [items]="sideNavItems"
+      [activeItemId]="activeSideItemId"
+      (itemSelected)="onNavItemSelected($event)"
+    ></app-side-nav>
+
+    <div class="app-workspace">
+      <div class="workspace-left">
+        <app-component-library
+          *ngIf="activePanelId === 'library'"
+          [components]="componentLibrary"
+          (addComponent)="onAddComponent($event)"
+        ></app-component-library>
+
+        <div class="placeholder-panel" *ngIf="activePanelId === 'models'">
+          <h3>Modelos em breve</h3>
+          <p>
+            Centralize visões recorrentes em modelos compartilháveis. Configure dimensões fixas,
+            filtros padrão e métricas calculadas.
+          </p>
+        </div>
+
+        <div class="placeholder-panel" *ngIf="activePanelId === 'settings'">
+          <h3>Configurações</h3>
+          <p>
+            Ajuste parâmetros do dashboard como tema visual, permissões e regras de publicação.
+          </p>
+        </div>
+      </div>
+
+      <ng-container *ngIf="(activePage$ | async) as activePage">
+        <div class="workspace-center">
+          <app-editor-toolbar
+            [viewMode]="viewMode"
+            (deviceModeChange)="onDeviceModeChange($event)"
+            (createPage)="onAddPage()"
+            (openDataSources)="onToggleDataSources()"
+          ></app-editor-toolbar>
+
+          <app-page-tabs
+            [pages]="pages"
+            [activePageId]="activePage?.id ?? ''"
+            (selectPage)="onPageSelected($event)"
+            (addPage)="onAddPage()"
+            (duplicatePage)="onDuplicatePage($event)"
+            (renamePage)="onRenamePage($event)"
+          ></app-page-tabs>
+
+          <app-canvas
+            [page]="activePage"
+            [viewMode]="viewMode"
+            [selectedComponent]="selectedComponent$ | async"
+            (selectComponent)="onComponentSelected($event)"
+            (componentMoved)="onComponentMoved($event)"
+          ></app-canvas>
+        </div>
+      </ng-container>
+
+      <div class="workspace-right">
+        <app-inspector
+          [component]="selectedComponent$ | async"
+          [dataSources]="dataSources$ | async"
+          (updateComponent)="onComponentUpdated($event)"
+        ></app-inspector>
+      </div>
+    </div>
+  </div>
+</div>
+
+<app-data-source-drawer
+  *ngIf="showDataSourcesDrawer"
+  [dataSources]="dataSources$ | async"
+  (close)="onCloseDataSources()"
+  (create)="onDataSourceCreated($event)"
+  (remove)="onDataSourceRemoved($event)"
+></app-data-source-drawer>
+
+<app-preview-overlay
+  *ngIf="showPreview"
+  [project]="project$ | async"
+  [pages]="(pages$ | async) ?? []"
+  [dataSources]="dataSources$ | async"
+  [activePageId]="(activePageId$ | async) ?? ''"
+  [viewMode]="viewMode"
+  (close)="onClosePreview()"
+  (selectPage)="onPreviewSelectPage($event)"
+  (changeDevice)="onDeviceModeChange($event)"
+></app-preview-overlay>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,64 @@
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  height: 100vh;
+  background: var(--color-surface);
+}
+
+.app-body {
+  flex: 1 1 auto;
+  display: flex;
+  min-height: 0;
+}
+
+.app-workspace {
+  flex: 1 1 auto;
+  display: flex;
+  min-height: 0;
+}
+
+.workspace-left {
+  width: 320px;
+  border-right: 1px solid var(--color-border);
+  background: #fff;
+  padding: 24px;
+  overflow-y: auto;
+}
+
+.workspace-center {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  gap: 16px;
+  min-width: 0;
+}
+
+.workspace-right {
+  width: 320px;
+  border-left: 1px solid var(--color-border);
+  background: #fff;
+  padding: 24px;
+  overflow-y: auto;
+}
+
+.placeholder-panel {
+  background: #fff;
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  box-shadow: var(--shadow-card);
+}
+
+.placeholder-panel h3 {
+  margin: 0 0 8px;
+  font-size: 18px;
+  color: var(--color-navy);
+}
+
+.placeholder-panel p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--color-muted);
+  line-height: 1.5;
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,0 +1,266 @@
+import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import {
+  ComponentTemplate,
+  DashboardComponentModel,
+  DashboardPage,
+  DashboardProject,
+  DataSource,
+  DeviceMode,
+  LayoutDimensions,
+  SideNavItem,
+} from './models/dashboard.models';
+import { BuilderStateService } from './services/builder-state.service';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss'],
+})
+export class AppComponent {
+  readonly project$: Observable<DashboardProject> = this.state.project$;
+  readonly pages$: Observable<DashboardPage[]> = this.state.pages$;
+  readonly activePage$ = this.state.activePage$;
+  readonly activePageId$ = this.state.activePageId$;
+  readonly selectedComponent$ = this.state.selectedComponent$;
+  readonly dataSources$: Observable<DataSource[]> = this.state.dataSources$;
+
+  readonly sideNavItems: SideNavItem[] = [
+    { id: 'library', icon: 'view_module', label: 'Componentes' },
+    { id: 'data', icon: 'database', label: 'Fontes de Dados' },
+    { id: 'models', icon: 'timeline', label: 'Modelos' },
+    { id: 'settings', icon: 'settings', label: 'Configurações' },
+  ];
+
+  activePanelId = 'library';
+  activeSideItemId = 'library';
+  viewMode: DeviceMode = 'desktop';
+  showDataSourcesDrawer = false;
+  showPreview = false;
+
+  readonly componentLibrary: ComponentTemplate[] = COMPONENT_LIBRARY;
+
+  constructor(private readonly state: BuilderStateService) {}
+
+  onAddComponent(template: ComponentTemplate): void {
+    this.state.addComponentFromTemplate(template);
+    this.activePanelId = 'library';
+    this.activeSideItemId = 'library';
+  }
+
+  onComponentSelected(component: DashboardComponentModel | null): void {
+    this.state.selectComponent(component?.id ?? null);
+  }
+
+  onComponentMoved(event: { componentId: string; position: LayoutDimensions }): void {
+    this.state.moveComponent(event.componentId, event.position);
+  }
+
+  onComponentUpdated(event: { componentId: string; changes: any }): void {
+    this.state.updateComponent(event.componentId, event.changes);
+  }
+
+  onNavItemSelected(itemId: string): void {
+    this.activeSideItemId = itemId;
+    if (itemId === 'data') {
+      this.showDataSourcesDrawer = true;
+      return;
+    }
+
+    this.activePanelId = itemId;
+  }
+
+  onCloseDataSources(): void {
+    this.showDataSourcesDrawer = false;
+    this.activeSideItemId = this.activePanelId;
+  }
+
+  onDataSourceCreated(dataSource: DataSource): void {
+    this.state.upsertDataSource(dataSource);
+  }
+
+  onDataSourceRemoved(dataSourceId: string): void {
+    this.state.removeDataSource(dataSourceId);
+  }
+
+  onPageSelected(pageId: string): void {
+    this.state.setActivePage(pageId);
+  }
+
+  onAddPage(): void {
+    this.state.addPage();
+  }
+
+  onDuplicatePage(pageId: string): void {
+    this.state.duplicatePage(pageId);
+  }
+
+  onRenamePage(event: { pageId: string; name: string }): void {
+    this.state.renamePage(event.pageId, event.name);
+  }
+
+  onDeviceModeChange(mode: DeviceMode): void {
+    this.viewMode = mode;
+  }
+
+  onToggleDataSources(): void {
+    this.showDataSourcesDrawer = !this.showDataSourcesDrawer;
+    this.activeSideItemId = this.showDataSourcesDrawer ? 'data' : this.activePanelId;
+  }
+
+  onPublish(): void {
+    this.state.updateProjectStatus('publicado');
+  }
+
+  onSaveDraft(): void {
+    this.state.updateProjectStatus('rascunho');
+  }
+
+  onPreview(): void {
+    this.showPreview = true;
+  }
+
+  onClosePreview(): void {
+    this.showPreview = false;
+  }
+
+  onPreviewSelectPage(pageId: string): void {
+    this.state.setActivePage(pageId);
+  }
+}
+
+const COMPONENT_LIBRARY: ComponentTemplate[] = [
+  {
+    id: 'kpi-principal',
+    name: 'Cartão KPI',
+    description: 'Indicador principal com variação vs. período anterior.',
+    type: 'kpi',
+    category: 'indicadores',
+    icon: 'speed',
+    defaultSize: { width: 280, height: 160 },
+    defaultData: {
+      metric: 'receita_total',
+      comparisonMetric: 'receita_total_anterior',
+    },
+  },
+  {
+    id: 'kpi-comparativo',
+    name: 'KPI Comparativo',
+    description: 'Cartão com duas métricas lado a lado para comparar indicadores.',
+    type: 'comparativo',
+    category: 'indicadores',
+    icon: 'monitoring',
+    defaultSize: { width: 320, height: 180 },
+    defaultData: {
+      metric: 'ticket_medio',
+      comparisonMetric: 'ticket_medio_anterior',
+    },
+  },
+  {
+    id: 'grafico-linhas',
+    name: 'Linha Temporal',
+    description: 'Gráfico de linhas para evolução de métricas ao longo do tempo.',
+    type: 'linha',
+    category: 'graficos',
+    icon: 'show_chart',
+    defaultSize: { width: 560, height: 320 },
+    defaultData: {
+      metric: 'receita_total',
+      dimension: 'mes',
+    },
+  },
+  {
+    id: 'grafico-barras',
+    name: 'Barras Agrupadas',
+    description: 'Comparação entre categorias utilizando barras verticais.',
+    type: 'barra',
+    category: 'graficos',
+    icon: 'stacked_bar_chart',
+    defaultSize: { width: 520, height: 320 },
+    defaultData: {
+      metric: 'quantidade_vendida',
+      dimension: 'categoria',
+    },
+  },
+  {
+    id: 'grafico-pizza',
+    name: 'Pizza / Donut',
+    description: 'Distribuição percentual por dimensão.',
+    type: 'pizza',
+    category: 'graficos',
+    icon: 'donut_small',
+    defaultSize: { width: 360, height: 300 },
+    defaultData: {
+      metric: 'receita_total',
+      dimension: 'regiao',
+    },
+  },
+  {
+    id: 'tabela-simples',
+    name: 'Tabela Resumo',
+    description: 'Tabela com métricas chave por dimensão.',
+    type: 'tabela',
+    category: 'tabelas',
+    icon: 'table_rows',
+    defaultSize: { width: 520, height: 320 },
+    defaultData: {
+      metric: 'receita_total',
+      dimension: 'vendedor',
+    },
+  },
+  {
+    id: 'tabela-dinamica',
+    name: 'Tabela Dinâmica',
+    description: 'Pivot table com agrupamentos personalizáveis.',
+    type: 'tabela-dinamica',
+    category: 'tabelas',
+    icon: 'pivot_table_chart',
+    defaultSize: { width: 560, height: 360 },
+  },
+  {
+    id: 'filtro-data',
+    name: 'Filtro de Datas',
+    description: 'Filtro de intervalo de datas com presets.',
+    type: 'filtro-data',
+    category: 'filtros',
+    icon: 'event',
+    defaultSize: { width: 280, height: 120 },
+  },
+  {
+    id: 'filtro-lista',
+    name: 'Filtro Multi-select',
+    description: 'Seleção de múltiplos valores com busca.',
+    type: 'filtro-lista',
+    category: 'filtros',
+    icon: 'filter_list',
+    defaultSize: { width: 280, height: 140 },
+  },
+  {
+    id: 'texto-livre',
+    name: 'Texto Rico',
+    description: 'Caixa de texto para títulos, descrições e instruções.',
+    type: 'texto',
+    category: 'texto',
+    icon: 'title',
+    defaultSize: { width: 360, height: 120 },
+  },
+  {
+    id: 'imagem-ilustrativa',
+    name: 'Imagem',
+    description: 'Bloco de imagem responsiva.',
+    type: 'imagem',
+    category: 'texto',
+    icon: 'image',
+    defaultSize: { width: 360, height: 220 },
+  },
+  {
+    id: 'iframe-externo',
+    name: 'Conteúdo Externo',
+    description: 'Embed de aplicações externas ou páginas web.',
+    type: 'iframe',
+    category: 'avancado',
+    icon: 'iframe',
+    defaultSize: { width: 520, height: 360 },
+  },
+];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,0 +1,41 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { DragDropModule } from '@angular/cdk/drag-drop';
+
+import { AppComponent } from './app.component';
+import { HeaderComponent } from './components/header/header.component';
+import { SideNavComponent } from './components/side-nav/side-nav.component';
+import { ComponentLibraryComponent } from './components/component-library/component-library.component';
+import { PageTabsComponent } from './components/page-tabs/page-tabs.component';
+import { CanvasComponent } from './components/canvas/canvas.component';
+import { InspectorComponent } from './components/inspector/inspector.component';
+import { DataSourceDrawerComponent } from './components/data-source-drawer/data-source-drawer.component';
+import { EditorToolbarComponent } from './components/editor-toolbar/editor-toolbar.component';
+import { PreviewOverlayComponent } from './components/preview-overlay/preview-overlay.component';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    HeaderComponent,
+    SideNavComponent,
+    ComponentLibraryComponent,
+    PageTabsComponent,
+    CanvasComponent,
+    InspectorComponent,
+    DataSourceDrawerComponent,
+    EditorToolbarComponent,
+    PreviewOverlayComponent,
+  ],
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    FormsModule,
+    ReactiveFormsModule,
+    DragDropModule,
+  ],
+  providers: [],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}

--- a/src/app/components/canvas/canvas.component.html
+++ b/src/app/components/canvas/canvas.component.html
@@ -1,0 +1,28 @@
+<div class="canvas" [ngClass]="canvasClass" (click)="onCanvasClick()">
+  <div class="canvas__grid"></div>
+
+  <div
+    *ngFor="let component of page?.components || []"
+    class="canvas__component"
+    cdkDrag
+    [cdkDragFreeDragPosition]="{ x: component.position.x, y: component.position.y }"
+    [ngClass]="{ 'canvas__component--selected': component.id === selectedComponent?.id }"
+    [ngStyle]="getComponentStyle(component)"
+    (cdkDragEnded)="onDragEnded(component, $event)"
+    (click)="onSelectComponent(component, $event)"
+  >
+    <header class="component-card__header">
+      <span class="component-card__type">{{ component.type | titlecase }}</span>
+      <span class="material-symbols-outlined drag-handle">drag_indicator</span>
+    </header>
+    <div class="component-card__body">
+      <h4>{{ component.title }}</h4>
+      <p *ngIf="component.subtitle">{{ component.subtitle }}</p>
+      <div class="component-card__data">
+        <span class="data-chip" *ngIf="component.data.metric">Métrica: {{ component.data.metric }}</span>
+        <span class="data-chip" *ngIf="component.data.dimension">Dimensão: {{ component.data.dimension }}</span>
+        <span class="data-chip" *ngIf="component.data.dataSourceId">Fonte: {{ component.data.dataSourceId }}</span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/components/canvas/canvas.component.scss
+++ b/src/app/components/canvas/canvas.component.scss
@@ -1,0 +1,93 @@
+.canvas {
+  position: relative;
+  flex: 1 1 auto;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px dashed rgba(13, 27, 42, 0.12);
+  overflow: hidden;
+  min-height: 600px;
+}
+
+.canvas--tablet {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.canvas--mobile {
+  max-width: 420px;
+  margin: 0 auto;
+}
+
+.canvas__grid {
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+      to right,
+      rgba(13, 27, 42, 0.05) 1px,
+      transparent 1px
+    ),
+    linear-gradient(to bottom, rgba(13, 27, 42, 0.05) 1px, transparent 1px);
+  background-size: 32px 32px;
+  pointer-events: none;
+}
+
+.canvas__component {
+  position: absolute;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  cursor: grab;
+  transition: box-shadow 0.15s ease, border 0.15s ease;
+}
+
+.canvas__component.cdk-drag-dragging {
+  cursor: grabbing;
+  box-shadow: 0 12px 28px rgba(13, 27, 42, 0.16);
+}
+
+.canvas__component--selected {
+  border: 2px solid var(--color-teal) !important;
+  box-shadow: 0 8px 24px rgba(46, 196, 182, 0.25);
+}
+
+.component-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-muted);
+}
+
+.drag-handle {
+  font-size: 18px;
+  color: var(--color-muted);
+}
+
+.component-card__body h4 {
+  margin: 0;
+  font-size: 16px;
+  color: var(--color-navy);
+}
+
+.component-card__body p {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+.component-card__data {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.data-chip {
+  background: rgba(13, 27, 42, 0.06);
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  color: var(--color-navy);
+}

--- a/src/app/components/canvas/canvas.component.ts
+++ b/src/app/components/canvas/canvas.component.ts
@@ -1,0 +1,62 @@
+import { CdkDragEnd } from '@angular/cdk/drag-drop';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+import {
+  DashboardComponentModel,
+  DashboardPage,
+  DeviceMode,
+  LayoutDimensions,
+} from '../../models/dashboard.models';
+
+@Component({
+  selector: 'app-canvas',
+  templateUrl: './canvas.component.html',
+  styleUrls: ['./canvas.component.scss'],
+})
+export class CanvasComponent {
+  @Input() page: DashboardPage | null = null;
+  @Input() viewMode: DeviceMode = 'desktop';
+  @Input() selectedComponent: DashboardComponentModel | null = null;
+
+  @Output() selectComponent = new EventEmitter<DashboardComponentModel | null>();
+  @Output() componentMoved = new EventEmitter<{ componentId: string; position: LayoutDimensions }>();
+
+  get canvasClass(): string {
+    return `canvas--${this.viewMode}`;
+  }
+
+  onCanvasClick(): void {
+    this.selectComponent.emit(null);
+  }
+
+  onSelectComponent(component: DashboardComponentModel, event: MouseEvent): void {
+    event.stopPropagation();
+    this.selectComponent.emit(component);
+  }
+
+  onDragEnded(component: DashboardComponentModel, event: CdkDragEnd): void {
+    const position = event.source.getFreeDragPosition();
+    const nextPosition: LayoutDimensions = {
+      x: Math.max(0, Math.round(position.x)),
+      y: Math.max(0, Math.round(position.y)),
+      width: component.position.width,
+      height: component.position.height,
+    };
+
+    this.componentMoved.emit({ componentId: component.id, position: nextPosition });
+  }
+
+  getComponentStyle(component: DashboardComponentModel): Record<string, string> {
+    return {
+      width: `${component.position.width}px`,
+      height: `${component.position.height}px`,
+      left: `${component.position.x}px`,
+      top: `${component.position.y}px`,
+      background: component.style.backgroundColor,
+      color: component.style.textColor,
+      borderRadius: `${component.style.cornerRadius}px`,
+      border: component.style.showBorder ? '1px solid var(--color-border)' : 'none',
+      boxShadow: component.style.showBorder ? 'none' : 'var(--shadow-card)',
+    };
+  }
+}

--- a/src/app/components/component-library/component-library.component.html
+++ b/src/app/components/component-library/component-library.component.html
@@ -1,0 +1,50 @@
+<section class="library">
+  <div class="library__header">
+    <h2>Biblioteca</h2>
+    <p>Adicione componentes pré-configurados inspirados no Looker Studio.</p>
+  </div>
+
+  <div class="library__search">
+    <span class="material-symbols-outlined">search</span>
+    <input
+      type="text"
+      placeholder="Buscar componentes"
+      [(ngModel)]="searchTerm"
+    />
+  </div>
+
+  <div class="library__categories">
+    <button
+      *ngFor="let category of categories"
+      type="button"
+      class="chip"
+      [class.chip--active]="category === activeCategory"
+      (click)="onSelectCategory(category)"
+    >
+      {{ category === 'todos' ? 'Todos' : (category | titlecase) }}
+    </button>
+  </div>
+
+  <div class="library__list">
+    <article
+      class="library-card"
+      *ngFor="let component of filteredComponents"
+      (click)="onAddComponent(component)"
+    >
+      <div class="library-card__icon">
+        <span class="material-symbols-outlined">{{ component.icon }}</span>
+      </div>
+      <div class="library-card__content">
+        <h3>{{ component.name }}</h3>
+        <p>{{ component.description }}</p>
+      </div>
+      <button
+        type="button"
+        class="add-button"
+        (click)="onAddComponent(component); $event.stopPropagation()"
+      >
+        <span class="material-symbols-outlined">add</span>
+      </button>
+    </article>
+  </div>
+</section>

--- a/src/app/components/component-library/component-library.component.scss
+++ b/src/app/components/component-library/component-library.component.scss
@@ -1,0 +1,125 @@
+.library {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.library__header h2 {
+  margin: 0;
+  font-size: 20px;
+  color: var(--color-navy);
+}
+
+.library__header p {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+.library__search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: 8px 12px;
+  border: 1px solid var(--color-border);
+}
+
+.library__search input {
+  flex: 1 1 auto;
+  border: none;
+  background: transparent;
+  font-size: 14px;
+  outline: none;
+}
+
+.library__categories {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 6px 14px;
+  background: #fff;
+  font-size: 13px;
+  color: var(--color-muted);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.chip--active {
+  background: rgba(46, 196, 182, 0.12);
+  color: var(--color-navy);
+  border-color: rgba(46, 196, 182, 0.4);
+}
+
+.library__list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.library-card {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 16px;
+  align-items: center;
+  padding: 16px;
+  background: #fff;
+  border-radius: var(--radius-lg);
+  border: 1px solid transparent;
+  box-shadow: var(--shadow-card);
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.library-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(13, 27, 42, 0.12);
+}
+
+.library-card__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: rgba(46, 196, 182, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-teal);
+}
+
+.library-card__content h3 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  color: var(--color-navy);
+}
+
+.library-card__content p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-muted);
+  line-height: 1.4;
+}
+
+.add-button {
+  background: rgba(46, 196, 182, 0.12);
+  color: var(--color-teal);
+  border: none;
+  border-radius: var(--radius-md);
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.add-button:hover {
+  background: rgba(46, 196, 182, 0.2);
+}

--- a/src/app/components/component-library/component-library.component.ts
+++ b/src/app/components/component-library/component-library.component.ts
@@ -1,0 +1,39 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+import { ComponentTemplate, ComponentCategory } from '../../models/dashboard.models';
+
+@Component({
+  selector: 'app-component-library',
+  templateUrl: './component-library.component.html',
+  styleUrls: ['./component-library.component.scss'],
+})
+export class ComponentLibraryComponent {
+  @Input() components: ComponentTemplate[] = [];
+
+  @Output() addComponent = new EventEmitter<ComponentTemplate>();
+
+  searchTerm = '';
+  activeCategory: ComponentCategory | 'todos' = 'indicadores';
+
+  get categories(): (ComponentCategory | 'todos')[] {
+    const base: ComponentCategory[] = Array.from(new Set(this.components.map(item => item.category)));
+    return ['todos', ...base];
+  }
+
+  get filteredComponents(): ComponentTemplate[] {
+    return this.components
+      .filter(item => this.activeCategory === 'todos' || item.category === this.activeCategory)
+      .filter(item =>
+        item.name.toLowerCase().includes(this.searchTerm.toLowerCase()) ||
+        item.description.toLowerCase().includes(this.searchTerm.toLowerCase()),
+      );
+  }
+
+  onSelectCategory(category: ComponentCategory | 'todos'): void {
+    this.activeCategory = category;
+  }
+
+  onAddComponent(component: ComponentTemplate): void {
+    this.addComponent.emit(component);
+  }
+}

--- a/src/app/components/data-source-drawer/data-source-drawer.component.html
+++ b/src/app/components/data-source-drawer/data-source-drawer.component.html
@@ -1,0 +1,66 @@
+<div class="drawer-backdrop" (click)="onClose()"></div>
+<aside class="drawer" role="dialog" aria-modal="true">
+  <header class="drawer__header">
+    <div>
+      <h2>Fontes de Dados</h2>
+      <p>Gerencie conexões e configure atualizações automáticas.</p>
+    </div>
+    <button type="button" class="icon-button" (click)="onClose()">
+      <span class="material-symbols-outlined">close</span>
+    </button>
+  </header>
+
+  <section class="drawer__content">
+    <div class="source-list">
+      <h3>Conexões existentes</h3>
+      <div class="source-card" *ngFor="let source of dataSources || []">
+        <div class="source-card__info">
+          <h4>{{ source.name }}</h4>
+          <p>{{ source.description }}</p>
+          <div class="source-card__meta">
+            <span class="meta-item">Tipo: {{ source.type | titlecase }}</span>
+            <span class="meta-item">Atualização: {{ source.refresh | titlecase }}</span>
+            <span class="meta-item">Responsável: {{ source.owner }}</span>
+          </div>
+        </div>
+        <button type="button" class="icon-button danger" (click)="onRemove(source.id)">
+          <span class="material-symbols-outlined">delete</span>
+        </button>
+      </div>
+      <p *ngIf="!dataSources || dataSources.length === 0" class="empty-text">
+        Nenhuma fonte cadastrada ainda. Adicione uma fonte abaixo.
+      </p>
+    </div>
+
+    <form class="new-source" [formGroup]="form" (ngSubmit)="onSubmit()">
+      <h3>Nova fonte</h3>
+      <label>
+        Nome
+        <input type="text" formControlName="name" required />
+      </label>
+      <label>
+        Tipo
+        <select formControlName="type">
+          <option *ngFor="let type of types" [value]="type.id">{{ type.label }}</option>
+        </select>
+      </label>
+      <label>
+        Frequência de atualização
+        <select formControlName="refresh">
+          <option *ngFor="let option of refreshOptions" [value]="option.id">
+            {{ option.label }}
+          </option>
+        </select>
+      </label>
+      <label>
+        Responsável
+        <input type="text" formControlName="owner" required />
+      </label>
+      <label>
+        Descrição
+        <textarea formControlName="description" rows="3" placeholder="Detalhe a origem dos dados"></textarea>
+      </label>
+      <button type="submit" class="submit-button">Adicionar fonte</button>
+    </form>
+  </section>
+</aside>

--- a/src/app/components/data-source-drawer/data-source-drawer.component.scss
+++ b/src/app/components/data-source-drawer/data-source-drawer.component.scss
@@ -1,0 +1,163 @@
+.drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(13, 27, 42, 0.4);
+  z-index: 10;
+}
+
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 420px;
+  height: 100vh;
+  background: #fff;
+  z-index: 11;
+  display: flex;
+  flex-direction: column;
+  box-shadow: -4px 0 24px rgba(13, 27, 42, 0.2);
+}
+
+.drawer__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 24px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.drawer__header h2 {
+  margin: 0;
+  font-size: 20px;
+  color: var(--color-navy);
+}
+
+.drawer__header p {
+  margin: 6px 0 0;
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+.drawer__content {
+  flex: 1 1 auto;
+  padding: 24px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.source-list h3,
+.new-source h3 {
+  margin: 0 0 12px;
+  font-size: 16px;
+  color: var(--color-navy);
+}
+
+.source-card {
+  display: flex;
+  gap: 12px;
+  padding: 16px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  margin-bottom: 12px;
+}
+
+.source-card__info h4 {
+  margin: 0 0 4px;
+  font-size: 15px;
+  color: var(--color-navy);
+}
+
+.source-card__info p {
+  margin: 0 0 8px;
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+.source-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+.meta-item {
+  background: rgba(13, 27, 42, 0.05);
+  padding: 4px 8px;
+  border-radius: 999px;
+}
+
+.icon-button {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(13, 27, 42, 0.08);
+  color: var(--color-navy);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.icon-button.danger {
+  background: rgba(255, 159, 28, 0.16);
+  color: var(--color-warning);
+}
+
+.empty-text {
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+.new-source {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  background: #fff;
+  box-shadow: var(--shadow-card);
+}
+
+.new-source label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+.new-source input,
+.new-source select,
+.new-source textarea {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  padding: 8px 10px;
+  font-size: 14px;
+  font-family: inherit;
+}
+
+.new-source textarea {
+  resize: vertical;
+}
+
+.submit-button {
+  align-self: flex-end;
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 10px 16px;
+  background: var(--color-teal);
+  color: #0d1b2a;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.submit-button:hover {
+  background: #24b6a9;
+}

--- a/src/app/components/data-source-drawer/data-source-drawer.component.ts
+++ b/src/app/components/data-source-drawer/data-source-drawer.component.ts
@@ -1,0 +1,73 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+
+import { DataSource } from '../../models/dashboard.models';
+import { createId } from '../../utils/id';
+
+@Component({
+  selector: 'app-data-source-drawer',
+  templateUrl: './data-source-drawer.component.html',
+  styleUrls: ['./data-source-drawer.component.scss'],
+})
+export class DataSourceDrawerComponent {
+  @Input() dataSources: DataSource[] | null = [];
+
+  @Output() close = new EventEmitter<void>();
+  @Output() create = new EventEmitter<DataSource>();
+  @Output() remove = new EventEmitter<string>();
+
+  readonly form: FormGroup;
+  readonly types = [
+    { id: 'sankhya', label: 'Sankhya ERP' },
+    { id: 'sql', label: 'Banco SQL' },
+    { id: 'rest', label: 'API REST' },
+    { id: 'csv', label: 'Arquivo CSV' },
+    { id: 'sheet', label: 'Google Sheets' },
+  ];
+
+  readonly refreshOptions = [
+    { id: 'tempo-real', label: 'Tempo real' },
+    { id: 'agendado', label: 'Agendado' },
+    { id: 'sob-demanda', label: 'Sob demanda' },
+  ];
+
+  constructor(private readonly fb: FormBuilder) {
+    this.form = this.fb.group({
+      name: ['', Validators.required],
+      type: ['sankhya', Validators.required],
+      refresh: ['agendado', Validators.required],
+      owner: ['', Validators.required],
+      description: [''],
+    });
+  }
+
+  onClose(): void {
+    this.close.emit();
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const value = this.form.value;
+    const dataSource: DataSource = {
+      id: createId('ds'),
+      name: value.name,
+      type: value.type,
+      refresh: value.refresh,
+      owner: value.owner,
+      description: value.description,
+      status: 'conectado',
+      lastUpdate: new Date().toISOString(),
+    };
+
+    this.create.emit(dataSource);
+    this.form.reset({ type: 'sankhya', refresh: 'agendado' });
+  }
+
+  onRemove(id: string): void {
+    this.remove.emit(id);
+  }
+}

--- a/src/app/components/editor-toolbar/editor-toolbar.component.html
+++ b/src/app/components/editor-toolbar/editor-toolbar.component.html
@@ -1,0 +1,28 @@
+<div class="toolbar">
+  <div class="toolbar__group">
+    <span class="toolbar__label">Responsividade</span>
+    <div class="device-toggle">
+      <button
+        *ngFor="let option of deviceOptions"
+        type="button"
+        class="device-toggle__button"
+        [class.device-toggle__button--active]="option.id === viewMode"
+        (click)="onSelectMode(option)"
+      >
+        <span class="material-symbols-outlined">{{ option.icon }}</span>
+        <span>{{ option.label }}</span>
+      </button>
+    </div>
+  </div>
+
+  <div class="toolbar__group">
+    <button type="button" class="toolbar-button" (click)="openDataSources.emit()">
+      <span class="material-symbols-outlined">storage</span>
+      Fontes de dados
+    </button>
+    <button type="button" class="toolbar-button" (click)="createPage.emit()">
+      <span class="material-symbols-outlined">add</span>
+      Página
+    </button>
+  </div>
+</div>

--- a/src/app/components/editor-toolbar/editor-toolbar.component.scss
+++ b/src/app/components/editor-toolbar/editor-toolbar.component.scss
@@ -1,0 +1,65 @@
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #fff;
+  border-radius: var(--radius-lg);
+  padding: 12px 16px;
+  box-shadow: var(--shadow-card);
+  gap: 16px;
+}
+
+.toolbar__group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.toolbar__label {
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+device-toggle,
+.device-toggle {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.device-toggle__button {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 8px 12px;
+  background: #fff;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--color-text);
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.device-toggle__button--active {
+  background: rgba(46, 196, 182, 0.18);
+  border-color: rgba(46, 196, 182, 0.6);
+}
+
+.toolbar-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(13, 27, 42, 0.06);
+  border-radius: var(--radius-md);
+  border: none;
+  padding: 8px 14px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-navy);
+  transition: background 0.15s ease;
+}
+
+.toolbar-button:hover {
+  background: rgba(13, 27, 42, 0.12);
+}

--- a/src/app/components/editor-toolbar/editor-toolbar.component.ts
+++ b/src/app/components/editor-toolbar/editor-toolbar.component.ts
@@ -1,0 +1,34 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+import { DeviceMode } from '../../models/dashboard.models';
+
+interface DeviceOption {
+  id: DeviceMode;
+  icon: string;
+  label: string;
+}
+
+@Component({
+  selector: 'app-editor-toolbar',
+  templateUrl: './editor-toolbar.component.html',
+  styleUrls: ['./editor-toolbar.component.scss'],
+})
+export class EditorToolbarComponent {
+  @Input() viewMode: DeviceMode = 'desktop';
+
+  @Output() deviceModeChange = new EventEmitter<DeviceMode>();
+  @Output() createPage = new EventEmitter<void>();
+  @Output() openDataSources = new EventEmitter<void>();
+
+  readonly deviceOptions: DeviceOption[] = [
+    { id: 'desktop', icon: 'desktop_windows', label: 'Desktop' },
+    { id: 'tablet', icon: 'tablet', label: 'Tablet' },
+    { id: 'mobile', icon: 'phone_iphone', label: 'Mobile' },
+  ];
+
+  onSelectMode(option: DeviceOption): void {
+    if (option.id !== this.viewMode) {
+      this.deviceModeChange.emit(option.id);
+    }
+  }
+}

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,0 +1,29 @@
+<header class="builder-header">
+  <div class="builder-header__left">
+    <div class="logo-badge">S</div>
+    <div class="project-info">
+      <span class="breadcrumb">Analytics / Dashboards</span>
+      <div class="project-title">{{ project?.name || 'Dashboard sem título' }}</div>
+      <div class="project-meta">
+        <span class="status-pill" [ngClass]="statusClass">{{ statusLabel }}</span>
+        <span class="separator">•</span>
+        <span class="updated-at">
+          Atualizado em {{ project?.lastUpdated | date: 'dd/MM/yyyy HH:mm' }}
+        </span>
+      </div>
+    </div>
+  </div>
+
+  <div class="builder-header__actions">
+    <button class="ghost" type="button" (click)="onToggleDataSources()">
+      <span class="material-symbols-outlined">storage</span>
+      Fontes de dados
+    </button>
+    <button class="ghost" type="button" (click)="preview.emit()">
+      <span class="material-symbols-outlined">visibility</span>
+      Visualizar
+    </button>
+    <button class="secondary" type="button" (click)="saveDraft.emit()">Salvar</button>
+    <button class="primary" type="button" (click)="publish.emit()">Publicar</button>
+  </div>
+</header>

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -1,0 +1,129 @@
+.builder-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  background: var(--color-navy);
+  color: #fff;
+  box-shadow: 0 2px 12px rgba(13, 27, 42, 0.2);
+}
+
+.builder-header__left {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.logo-badge {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 20px;
+}
+
+.project-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.breadcrumb {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.project-title {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.project-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.status-pill {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-weight: 500;
+}
+
+.status-pill--draft {
+  background: rgba(255, 255, 255, 0.16);
+  color: #fff;
+}
+
+.status-pill--published {
+  background: rgba(46, 196, 182, 0.2);
+  color: #2ec4b6;
+}
+
+.separator {
+  opacity: 0.6;
+}
+
+.builder-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: var(--radius-md);
+  padding: 10px 16px;
+  font-size: 14px;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+
+button .material-symbols-outlined {
+  font-size: 18px;
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+button:active {
+  transform: translateY(0);
+}
+
+button.ghost {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}
+
+button.ghost:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+button.secondary {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+}
+
+button.secondary:hover {
+  background: rgba(255, 255, 255, 0.26);
+}
+
+button.primary {
+  background: var(--color-teal);
+  color: #0d1b2a;
+  font-weight: 600;
+}
+
+button.primary:hover {
+  background: #24b6a9;
+}

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -1,0 +1,33 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+import { DashboardProject } from '../../models/dashboard.models';
+
+@Component({
+  selector: 'app-header',
+  templateUrl: './header.component.html',
+  styleUrls: ['./header.component.scss'],
+})
+export class HeaderComponent {
+  @Input() project: DashboardProject | null = null;
+
+  @Output() toggleDataSources = new EventEmitter<void>();
+  @Output() publish = new EventEmitter<void>();
+  @Output() saveDraft = new EventEmitter<void>();
+  @Output() preview = new EventEmitter<void>();
+
+  get statusLabel(): string {
+    if (!this.project) {
+      return 'Rascunho';
+    }
+
+    return this.project.status === 'publicado' ? 'Publicado' : 'Rascunho';
+  }
+
+  get statusClass(): string {
+    return this.project?.status === 'publicado' ? 'status-pill--published' : 'status-pill--draft';
+  }
+
+  onToggleDataSources(): void {
+    this.toggleDataSources.emit();
+  }
+}

--- a/src/app/components/inspector/inspector.component.html
+++ b/src/app/components/inspector/inspector.component.html
@@ -1,0 +1,80 @@
+<section class="inspector">
+  <h2>Inspector</h2>
+  <p class="inspector__subtitle">
+    Ajuste propriedades, dados e estilos do componente selecionado.
+  </p>
+
+  <ng-container *ngIf="component; else emptyState">
+    <form [formGroup]="form" class="inspector__form">
+      <div class="form-section">
+        <h3>Identidade</h3>
+        <label>
+          Título
+          <input type="text" formControlName="title" />
+        </label>
+        <label>
+          Subtítulo
+          <input type="text" formControlName="subtitle" />
+        </label>
+      </div>
+
+      <div class="form-section">
+        <h3>Dados</h3>
+        <label>
+          Fonte de dados
+          <select formControlName="dataSourceId">
+            <option value="">Selecione uma fonte</option>
+            <option *ngFor="let source of dataSources || []" [value]="source.id">
+              {{ source.name }}
+            </option>
+          </select>
+        </label>
+        <label>
+          Métrica
+          <input type="text" formControlName="metric" placeholder="Ex.: receita_total" />
+        </label>
+        <label>
+          Dimensão
+          <input type="text" formControlName="dimension" placeholder="Ex.: mes" />
+        </label>
+        <label>
+          Métrica de comparação
+          <input type="text" formControlName="comparisonMetric" placeholder="Ex.: receita_anterior" />
+        </label>
+      </div>
+
+      <div class="form-section">
+        <h3>Estilo</h3>
+        <div class="color-row">
+          <label>
+            Fundo
+            <input type="color" formControlName="backgroundColor" />
+          </label>
+          <label>
+            Acento
+            <input type="color" formControlName="accentColor" />
+          </label>
+          <label>
+            Texto
+            <input type="color" formControlName="textColor" />
+          </label>
+        </div>
+        <label class="checkbox">
+          <input type="checkbox" formControlName="showBorder" />
+          Exibir borda
+        </label>
+        <label>
+          Raio da borda (px)
+          <input type="number" formControlName="cornerRadius" min="0" max="32" />
+        </label>
+      </div>
+    </form>
+  </ng-container>
+
+  <ng-template #emptyState>
+    <div class="inspector__empty">
+      <span class="material-symbols-outlined">stylus_note</span>
+      <p>Selecione um componente no canvas para editar suas propriedades.</p>
+    </div>
+  </ng-template>
+</section>

--- a/src/app/components/inspector/inspector.component.scss
+++ b/src/app/components/inspector/inspector.component.scss
@@ -1,0 +1,101 @@
+.inspector {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.inspector h2 {
+  margin: 0;
+  font-size: 20px;
+  color: var(--color-navy);
+}
+
+.inspector__subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+.inspector__form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.form-section {
+  background: #fff;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.form-section h3 {
+  margin: 0;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-muted);
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+input,
+select {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  padding: 8px 10px;
+  font-size: 14px;
+  font-family: inherit;
+}
+
+input[type='color'] {
+  padding: 0;
+  height: 36px;
+}
+
+.color-row {
+  display: flex;
+  gap: 12px;
+}
+
+.color-row label {
+  flex: 1 1 0;
+}
+
+.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.checkbox input {
+  width: auto;
+}
+
+.inspector__empty {
+  background: #fff;
+  border-radius: var(--radius-lg);
+  border: 1px dashed var(--color-border);
+  padding: 48px 16px;
+  text-align: center;
+  color: var(--color-muted);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.inspector__empty .material-symbols-outlined {
+  font-size: 40px;
+  color: var(--color-navy);
+  opacity: 0.4;
+}

--- a/src/app/components/inspector/inspector.component.ts
+++ b/src/app/components/inspector/inspector.component.ts
@@ -1,0 +1,99 @@
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, SimpleChanges, Output } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { Subject, debounceTime, takeUntil } from 'rxjs';
+
+import { DashboardComponentModel, DataSource } from '../../models/dashboard.models';
+
+@Component({
+  selector: 'app-inspector',
+  templateUrl: './inspector.component.html',
+  styleUrls: ['./inspector.component.scss'],
+})
+export class InspectorComponent implements OnChanges, OnDestroy {
+  @Input() component: DashboardComponentModel | null = null;
+  @Input() dataSources: DataSource[] | null = [];
+
+  @Output() updateComponent = new EventEmitter<{ componentId: string; changes: any }>();
+
+  form: FormGroup;
+  private readonly destroy$ = new Subject<void>();
+  private patching = false;
+
+  constructor(private readonly fb: FormBuilder) {
+    this.form = this.fb.group({
+      title: [''],
+      subtitle: [''],
+      dataSourceId: [''],
+      metric: [''],
+      dimension: [''],
+      comparisonMetric: [''],
+      backgroundColor: ['#ffffff'],
+      accentColor: ['#2ec4b6'],
+      textColor: ['#0d1b2a'],
+      showBorder: [false],
+      cornerRadius: [12],
+    });
+
+    this.form.valueChanges.pipe(debounceTime(150), takeUntil(this.destroy$)).subscribe(value => {
+      if (!this.component || this.patching) {
+        return;
+      }
+
+      this.updateComponent.emit({
+        componentId: this.component.id,
+        changes: {
+          title: value.title,
+          subtitle: value.subtitle,
+          data: {
+            dataSourceId: value.dataSourceId,
+            metric: value.metric,
+            dimension: value.dimension,
+            comparisonMetric: value.comparisonMetric,
+          },
+          style: {
+            backgroundColor: value.backgroundColor,
+            accentColor: value.accentColor,
+            textColor: value.textColor,
+            showBorder: value.showBorder,
+            cornerRadius: value.cornerRadius,
+          },
+        },
+      });
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['component']) {
+      this.patching = true;
+      const current = changes['component'].currentValue as DashboardComponentModel | null;
+      if (current) {
+        this.form.enable({ emitEvent: false });
+        this.form.patchValue(
+          {
+            title: current.title,
+            subtitle: current.subtitle ?? '',
+            dataSourceId: current.data.dataSourceId ?? '',
+            metric: current.data.metric ?? '',
+            dimension: current.data.dimension ?? '',
+            comparisonMetric: current.data.comparisonMetric ?? '',
+            backgroundColor: current.style.backgroundColor,
+            accentColor: current.style.accentColor,
+            textColor: current.style.textColor,
+            showBorder: current.style.showBorder,
+            cornerRadius: current.style.cornerRadius,
+          },
+          { emitEvent: false },
+        );
+      } else {
+        this.form.reset({}, { emitEvent: false });
+        this.form.disable({ emitEvent: false });
+      }
+      this.patching = false;
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/src/app/components/page-tabs/page-tabs.component.html
+++ b/src/app/components/page-tabs/page-tabs.component.html
@@ -1,0 +1,28 @@
+<div class="page-tabs">
+  <div class="page-tabs__list">
+    <button
+      *ngFor="let page of pages"
+      type="button"
+      class="page-tab"
+      [class.page-tab--active]="page.id === activePageId"
+      (click)="onSelect(page)"
+    >
+      <span class="page-tab__name">{{ page.name }}</span>
+      <div class="page-tab__actions">
+        <button type="button" class="icon-button" (click)="onRename(page, $event)">
+          <span class="material-symbols-outlined">edit</span>
+        </button>
+        <button type="button" class="icon-button" (click)="onDuplicate(page, $event)">
+          <span class="material-symbols-outlined">content_copy</span>
+        </button>
+      </div>
+    </button>
+  </div>
+
+  <div class="page-tabs__actions">
+    <button type="button" class="add-page" (click)="addPage.emit()">
+      <span class="material-symbols-outlined">add</span>
+      Nova página
+    </button>
+  </div>
+</div>

--- a/src/app/components/page-tabs/page-tabs.component.scss
+++ b/src/app/components/page-tabs/page-tabs.component.scss
@@ -1,0 +1,83 @@
+.page-tabs {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  background: #fff;
+  padding: 12px 16px;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+}
+
+.page-tabs__list {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  overflow-x: auto;
+}
+
+.page-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 8px 14px;
+  background: #fff;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.page-tab--active {
+  background: rgba(46, 196, 182, 0.18);
+  border-color: rgba(46, 196, 182, 0.6);
+}
+
+.page-tab__name {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.page-tab__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.icon-button {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--color-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.icon-button:hover {
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--color-navy);
+}
+
+.page-tabs__actions .add-page {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--color-navy);
+  color: #fff;
+  padding: 10px 16px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background 0.15s ease;
+}
+
+.page-tabs__actions .add-page:hover {
+  background: var(--color-navy-strong);
+}

--- a/src/app/components/page-tabs/page-tabs.component.ts
+++ b/src/app/components/page-tabs/page-tabs.component.ts
@@ -1,0 +1,35 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+import { DashboardPage } from '../../models/dashboard.models';
+
+@Component({
+  selector: 'app-page-tabs',
+  templateUrl: './page-tabs.component.html',
+  styleUrls: ['./page-tabs.component.scss'],
+})
+export class PageTabsComponent {
+  @Input() pages: DashboardPage[] = [];
+  @Input() activePageId = '';
+
+  @Output() selectPage = new EventEmitter<string>();
+  @Output() addPage = new EventEmitter<void>();
+  @Output() duplicatePage = new EventEmitter<string>();
+  @Output() renamePage = new EventEmitter<{ pageId: string; name: string }>();
+
+  onSelect(page: DashboardPage): void {
+    this.selectPage.emit(page.id);
+  }
+
+  onDuplicate(page: DashboardPage, event: MouseEvent): void {
+    event.stopPropagation();
+    this.duplicatePage.emit(page.id);
+  }
+
+  onRename(page: DashboardPage, event: MouseEvent): void {
+    event.stopPropagation();
+    const name = prompt('Renomear página', page.name);
+    if (name && name.trim().length > 0) {
+      this.renamePage.emit({ pageId: page.id, name: name.trim() });
+    }
+  }
+}

--- a/src/app/components/preview-overlay/preview-overlay.component.html
+++ b/src/app/components/preview-overlay/preview-overlay.component.html
@@ -1,0 +1,96 @@
+<div class="preview-overlay">
+  <div class="preview-overlay__backdrop" (click)="onClose()" aria-hidden="true"></div>
+
+  <div class="preview-overlay__panel">
+    <header class="preview-overlay__header">
+      <div class="preview-overlay__title">
+        <span class="badge">Pré-visualização</span>
+        <h2>{{ project?.name || 'Dashboard sem título' }}</h2>
+        <p class="meta" *ngIf="project">
+          Pasta {{ project.folder }} • Atualizado em {{ project.lastUpdated | date: 'dd/MM/yyyy HH:mm' }}
+        </p>
+      </div>
+
+      <div class="preview-overlay__header-actions">
+        <span class="status-pill" [ngClass]="statusClass">{{ statusLabel }}</span>
+        <button
+          type="button"
+          class="icon-button"
+          (click)="onClose()"
+          aria-label="Fechar pré-visualização"
+        >
+          <span class="material-symbols-outlined">close</span>
+        </button>
+      </div>
+    </header>
+
+    <div class="preview-overlay__controls" *ngIf="pages.length">
+      <nav class="preview-pages">
+        <button
+          type="button"
+          *ngFor="let page of pages"
+          class="preview-pages__item"
+          [class.preview-pages__item--active]="page.id === (activePage?.id || '')"
+          (click)="onSelectPage(page.id)"
+        >
+          {{ page.name }}
+        </button>
+      </nav>
+
+      <div class="preview-devices">
+        <button
+          type="button"
+          *ngFor="let device of deviceModes"
+          class="preview-devices__item"
+          [class.preview-devices__item--active]="device.id === viewMode"
+          (click)="onChangeDevice(device.id)"
+        >
+          <span class="material-symbols-outlined">{{ device.icon }}</span>
+          {{ device.label }}
+        </button>
+      </div>
+    </div>
+
+    <section class="preview-overlay__canvas" *ngIf="activePage as page">
+      <div class="preview-canvas" [ngClass]="'preview-canvas--' + viewMode">
+        <div class="preview-canvas__grid"></div>
+
+        <article
+          class="preview-card"
+          *ngFor="let component of page.components"
+          [ngStyle]="getComponentStyle(component)"
+        >
+          <header class="preview-card__header">
+            <span class="preview-card__type">{{ component.type | titlecase }}</span>
+            <ng-container *ngIf="resolveDataSourceName(component.data.dataSourceId) as sourceName">
+              <span class="data-source">Fonte: {{ sourceName }}</span>
+            </ng-container>
+          </header>
+          <div class="preview-card__body">
+            <h3>{{ component.title }}</h3>
+            <p *ngIf="component.subtitle">{{ component.subtitle }}</p>
+            <div class="preview-card__chips">
+              <span class="chip" *ngIf="component.data.metric">Métrica: {{ component.data.metric }}</span>
+              <span class="chip" *ngIf="component.data.dimension"
+                >Dimensão: {{ component.data.dimension }}</span
+              >
+              <span class="chip" *ngIf="component.data.comparisonMetric"
+                >Comparação: {{ component.data.comparisonMetric }}</span
+              >
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="preview-overlay__summary" *ngIf="dataSources?.length">
+      <h3>Fontes de dados conectadas</h3>
+      <div class="preview-overlay__sources">
+        <div class="source-pill" *ngFor="let source of dataSources">
+          <span class="source-pill__name">{{ source.name }}</span>
+          <span class="source-pill__meta">{{ source.type | uppercase }} • {{ source.refresh | titlecase }}</span>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>

--- a/src/app/components/preview-overlay/preview-overlay.component.scss
+++ b/src/app/components/preview-overlay/preview-overlay.component.scss
@@ -1,0 +1,305 @@
+.preview-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.preview-overlay__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(13, 27, 42, 0.55);
+}
+
+.preview-overlay__panel {
+  position: relative;
+  width: min(1120px, calc(100% - 64px));
+  max-height: calc(100% - 64px);
+  background: #fff;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 24px 60px rgba(13, 27, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.preview-overlay__header {
+  padding: 24px 32px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+}
+
+.preview-overlay__title h2 {
+  margin: 8px 0 0;
+  font-size: 24px;
+  color: var(--color-navy);
+}
+
+.preview-overlay__title .meta {
+  margin: 8px 0 0;
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-teal);
+}
+
+.preview-overlay__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.status-pill {
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.status-pill--draft {
+  background: rgba(13, 27, 42, 0.08);
+  color: var(--color-navy);
+}
+
+.status-pill--published {
+  background: rgba(46, 196, 182, 0.18);
+  color: var(--color-teal);
+}
+
+.icon-button {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(13, 27, 42, 0.08);
+  color: var(--color-navy);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.icon-button:hover {
+  background: rgba(13, 27, 42, 0.12);
+}
+
+.preview-overlay__controls {
+  padding: 0 32px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.preview-pages {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.preview-pages__item {
+  border: none;
+  border-radius: 999px;
+  padding: 8px 16px;
+  background: rgba(13, 27, 42, 0.06);
+  color: var(--color-navy);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.preview-pages__item--active {
+  background: var(--color-teal);
+  color: #0d1b2a;
+  transform: translateY(-1px);
+}
+
+.preview-devices {
+  display: flex;
+  gap: 8px;
+}
+
+.preview-devices__item {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 8px 14px;
+  background: #fff;
+  color: var(--color-navy);
+  font-size: 13px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: border 0.15s ease, background 0.15s ease, transform 0.15s ease;
+}
+
+.preview-devices__item--active {
+  border-color: var(--color-teal);
+  background: rgba(46, 196, 182, 0.15);
+  transform: translateY(-1px);
+}
+
+.preview-overlay__canvas {
+  padding: 16px 32px 24px;
+  overflow: auto;
+}
+
+.preview-canvas {
+  position: relative;
+  margin: 0 auto;
+  min-height: 560px;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px dashed rgba(13, 27, 42, 0.16);
+  overflow: hidden;
+}
+
+.preview-canvas--tablet {
+  max-width: 900px;
+}
+
+.preview-canvas--mobile {
+  max-width: 420px;
+}
+
+.preview-canvas__grid {
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+      to right,
+      rgba(13, 27, 42, 0.05) 1px,
+      transparent 1px
+    ),
+    linear-gradient(to bottom, rgba(13, 27, 42, 0.05) 1px, transparent 1px);
+  background-size: 32px 32px;
+  pointer-events: none;
+}
+
+.preview-card {
+  position: absolute;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  backdrop-filter: blur(0.5px);
+}
+
+.preview-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-muted);
+}
+
+.preview-card__type {
+  font-weight: 600;
+}
+
+.data-source {
+  font-size: 11px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(13, 27, 42, 0.06);
+  color: var(--color-navy);
+}
+
+.preview-card__body h3 {
+  margin: 0;
+  font-size: 18px;
+  color: var(--color-navy);
+}
+
+.preview-card__body p {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+.preview-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(46, 196, 182, 0.2);
+  color: var(--color-navy);
+}
+
+.preview-overlay__summary {
+  padding: 16px 32px 28px;
+  border-top: 1px solid var(--color-border);
+  background: #fbfcfe;
+}
+
+.preview-overlay__summary h3 {
+  margin: 0 0 12px;
+  font-size: 16px;
+  color: var(--color-navy);
+}
+
+.preview-overlay__sources {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.source-pill {
+  border-radius: var(--radius-md);
+  background: #fff;
+  border: 1px solid var(--color-border);
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 200px;
+}
+
+.source-pill__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-navy);
+}
+
+.source-pill__meta {
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+@media (max-width: 960px) {
+  .preview-overlay__panel {
+    width: calc(100% - 32px);
+    max-height: calc(100% - 32px);
+  }
+
+  .preview-overlay__controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .preview-devices {
+    justify-content: flex-start;
+  }
+}

--- a/src/app/components/preview-overlay/preview-overlay.component.ts
+++ b/src/app/components/preview-overlay/preview-overlay.component.ts
@@ -1,0 +1,83 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+import {
+  DashboardComponentModel,
+  DashboardPage,
+  DashboardProject,
+  DataSource,
+  DeviceMode,
+} from '../../models/dashboard.models';
+
+@Component({
+  selector: 'app-preview-overlay',
+  templateUrl: './preview-overlay.component.html',
+  styleUrls: ['./preview-overlay.component.scss'],
+})
+export class PreviewOverlayComponent {
+  @Input() project: DashboardProject | null = null;
+  @Input() pages: DashboardPage[] = [];
+  @Input() dataSources: DataSource[] | null = [];
+  @Input() activePageId = '';
+  @Input() viewMode: DeviceMode = 'desktop';
+
+  @Output() close = new EventEmitter<void>();
+  @Output() selectPage = new EventEmitter<string>();
+  @Output() changeDevice = new EventEmitter<DeviceMode>();
+
+  readonly deviceModes: { id: DeviceMode; label: string; icon: string }[] = [
+    { id: 'desktop', label: 'Desktop', icon: 'desktop_windows' },
+    { id: 'tablet', label: 'Tablet', icon: 'tablet' },
+    { id: 'mobile', label: 'Mobile', icon: 'phone_iphone' },
+  ];
+
+  get activePage(): DashboardPage | null {
+    return this.pages.find(page => page.id === this.activePageId) ?? this.pages[0] ?? null;
+  }
+
+  get statusLabel(): string {
+    if (!this.project) {
+      return 'Rascunho';
+    }
+
+    return this.project.status === 'publicado' ? 'Publicado' : 'Rascunho';
+  }
+
+  get statusClass(): string {
+    return this.project?.status === 'publicado' ? 'status-pill--published' : 'status-pill--draft';
+  }
+
+  onClose(): void {
+    this.close.emit();
+  }
+
+  onSelectPage(pageId: string): void {
+    this.selectPage.emit(pageId);
+  }
+
+  onChangeDevice(mode: DeviceMode): void {
+    this.changeDevice.emit(mode);
+  }
+
+  getComponentStyle(component: DashboardComponentModel): Record<string, string> {
+    return {
+      width: `${component.position.width}px`,
+      height: `${component.position.height}px`,
+      left: `${component.position.x}px`,
+      top: `${component.position.y}px`,
+      background: component.style.backgroundColor,
+      color: component.style.textColor,
+      borderRadius: `${component.style.cornerRadius}px`,
+      border: component.style.showBorder ? `1px solid ${component.style.accentColor}` : 'none',
+      boxShadow: component.style.showBorder ? 'none' : 'var(--shadow-card)',
+    };
+  }
+
+  resolveDataSourceName(id?: string): string | null {
+    if (!id) {
+      return null;
+    }
+
+    const match = (this.dataSources ?? []).find(source => source.id === id);
+    return match?.name ?? id;
+  }
+}

--- a/src/app/components/side-nav/side-nav.component.html
+++ b/src/app/components/side-nav/side-nav.component.html
@@ -1,0 +1,12 @@
+<nav class="side-nav">
+  <button
+    *ngFor="let item of items"
+    type="button"
+    class="side-nav__item"
+    [class.side-nav__item--active]="item.id === activeItemId"
+    (click)="onSelect(item)"
+  >
+    <span class="material-symbols-outlined">{{ item.icon }}</span>
+    <span class="side-nav__label">{{ item.label }}</span>
+  </button>
+</nav>

--- a/src/app/components/side-nav/side-nav.component.scss
+++ b/src/app/components/side-nav/side-nav.component.scss
@@ -1,0 +1,47 @@
+.side-nav {
+  width: 72px;
+  background: var(--color-navy-strong);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px 0;
+  gap: 12px;
+}
+
+.side-nav__item {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+
+.side-nav__item:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+.side-nav__item--active {
+  background: rgba(46, 196, 182, 0.25);
+  color: #fff;
+  box-shadow: inset 0 0 0 1px rgba(46, 196, 182, 0.6);
+}
+
+.side-nav__label {
+  font-size: 10px;
+  line-height: 1;
+  font-weight: 500;
+}
+
+.material-symbols-outlined {
+  font-size: 22px;
+}

--- a/src/app/components/side-nav/side-nav.component.ts
+++ b/src/app/components/side-nav/side-nav.component.ts
@@ -1,0 +1,19 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+import { SideNavItem } from '../../models/dashboard.models';
+
+@Component({
+  selector: 'app-side-nav',
+  templateUrl: './side-nav.component.html',
+  styleUrls: ['./side-nav.component.scss'],
+})
+export class SideNavComponent {
+  @Input() items: SideNavItem[] = [];
+  @Input() activeItemId: string | null = null;
+
+  @Output() itemSelected = new EventEmitter<string>();
+
+  onSelect(item: SideNavItem): void {
+    this.itemSelected.emit(item.id);
+  }
+}

--- a/src/app/models/dashboard.models.ts
+++ b/src/app/models/dashboard.models.ts
@@ -1,0 +1,105 @@
+export type DashboardComponentType =
+  | 'kpi'
+  | 'comparativo'
+  | 'barra'
+  | 'linha'
+  | 'pizza'
+  | 'area'
+  | 'tabela'
+  | 'tabela-dinamica'
+  | 'mapa'
+  | 'filtro-data'
+  | 'filtro-lista'
+  | 'texto'
+  | 'imagem'
+  | 'iframe';
+
+export interface LayoutDimensions {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface DashboardComponentDataBinding {
+  dataSourceId?: string;
+  metric?: string;
+  dimension?: string;
+  comparisonMetric?: string;
+  filters?: string[];
+}
+
+export interface DashboardComponentStyle {
+  backgroundColor: string;
+  accentColor: string;
+  textColor: string;
+  showBorder: boolean;
+  cornerRadius: number;
+}
+
+export interface DashboardComponentModel {
+  id: string;
+  templateId: string;
+  title: string;
+  subtitle?: string;
+  type: DashboardComponentType;
+  position: LayoutDimensions;
+  data: DashboardComponentDataBinding;
+  style: DashboardComponentStyle;
+}
+
+export interface DashboardPage {
+  id: string;
+  name: string;
+  components: DashboardComponentModel[];
+}
+
+export interface DashboardProject {
+  id: string;
+  name: string;
+  folder: string;
+  status: 'rascunho' | 'publicado';
+  description?: string;
+  lastUpdated: string;
+}
+
+export type ComponentCategory =
+  | 'indicadores'
+  | 'graficos'
+  | 'tabelas'
+  | 'filtros'
+  | 'texto'
+  | 'avancado';
+
+export interface ComponentTemplate {
+  id: string;
+  name: string;
+  description: string;
+  type: DashboardComponentType;
+  category: ComponentCategory;
+  icon: string;
+  defaultSize: {
+    width: number;
+    height: number;
+  };
+  defaultData?: Partial<DashboardComponentDataBinding>;
+}
+
+export interface DataSource {
+  id: string;
+  name: string;
+  type: 'sql' | 'rest' | 'csv' | 'sankhya' | 'sheet';
+  status: 'conectado' | 'erro' | 'desconectado';
+  refresh: 'tempo-real' | 'sob-demanda' | 'agendado';
+  lastUpdate: string;
+  owner: string;
+  description?: string;
+}
+
+export type DeviceMode = 'desktop' | 'tablet' | 'mobile';
+
+export interface SideNavItem {
+  id: string;
+  icon: string;
+  label: string;
+}

--- a/src/app/services/builder-state.service.ts
+++ b/src/app/services/builder-state.service.ts
@@ -1,0 +1,356 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, combineLatest, map } from 'rxjs';
+
+import {
+  ComponentTemplate,
+  DashboardComponentDataBinding,
+  DashboardComponentModel,
+  DashboardComponentStyle,
+  DashboardPage,
+  DashboardProject,
+  DataSource,
+  LayoutDimensions,
+} from '../models/dashboard.models';
+import { createId } from '../utils/id';
+
+interface ComponentUpdate {
+  title?: string;
+  subtitle?: string;
+  data?: Partial<DashboardComponentDataBinding>;
+  style?: Partial<DashboardComponentStyle>;
+  position?: Partial<LayoutDimensions>;
+}
+
+@Injectable({ providedIn: 'root' })
+export class BuilderStateService {
+  private readonly projectSubject = new BehaviorSubject<DashboardProject>({
+    id: createId('project'),
+    name: 'Vendas - Painel Executivo',
+    folder: 'Diretoria',
+    status: 'rascunho',
+    description: 'Painel integrado com visão geral de vendas e indicadores críticos.',
+    lastUpdated: new Date().toISOString(),
+  });
+
+  private readonly pagesSubject = new BehaviorSubject<DashboardPage[]>(this.buildInitialPages());
+  private readonly activePageIdSubject = new BehaviorSubject<string>(this.pagesSubject.value[0]?.id ?? '');
+  private readonly selectedComponentIdSubject = new BehaviorSubject<string | null>(
+    this.pagesSubject.value[0]?.components[0]?.id ?? null,
+  );
+  private readonly dataSourcesSubject = new BehaviorSubject<DataSource[]>(this.buildInitialDataSources());
+
+  readonly project$ = this.projectSubject.asObservable();
+  readonly pages$ = this.pagesSubject.asObservable();
+  readonly activePageId$ = this.activePageIdSubject.asObservable();
+  readonly dataSources$ = this.dataSourcesSubject.asObservable();
+
+  readonly activePage$ = combineLatest([this.pages$, this.activePageId$]).pipe(
+    map(([pages, activeId]) => pages.find(page => page.id === activeId) ?? null),
+  );
+
+  readonly selectedComponent$ = combineLatest([
+    this.activePage$,
+    this.selectedComponentIdSubject.asObservable(),
+  ]).pipe(
+    map(([page, componentId]) => page?.components.find(component => component.id === componentId) ?? null),
+  );
+
+  addComponentFromTemplate(template: ComponentTemplate): void {
+    const activePageId = this.activePageIdSubject.value;
+    if (!activePageId) {
+      return;
+    }
+
+    const pages = this.pagesSubject.value;
+    const pageIndex = pages.findIndex(page => page.id === activePageId);
+    if (pageIndex === -1) {
+      return;
+    }
+
+    const targetPage = pages[pageIndex];
+    const newComponent = this.createComponentFromTemplate(template, targetPage);
+    const updatedPage: DashboardPage = {
+      ...targetPage,
+      components: [...targetPage.components, newComponent],
+    };
+
+    const updatedPages = [...pages];
+    updatedPages[pageIndex] = updatedPage;
+    this.pagesSubject.next(updatedPages);
+    this.selectedComponentIdSubject.next(newComponent.id);
+    this.touchProject();
+  }
+
+  updateComponent(componentId: string, changes: ComponentUpdate): void {
+    const pages = this.pagesSubject.value.map(page => {
+      const hasComponent = page.components.some(component => component.id === componentId);
+      if (!hasComponent) {
+        return page;
+      }
+
+      const updatedComponents = page.components.map(component => {
+        if (component.id !== componentId) {
+          return component;
+        }
+
+        return {
+          ...component,
+          title: changes.title ?? component.title,
+          subtitle: changes.subtitle ?? component.subtitle,
+          data: {
+            ...component.data,
+            ...changes.data,
+          },
+          style: {
+            ...component.style,
+            ...changes.style,
+          },
+          position: {
+            ...component.position,
+            ...changes.position,
+          },
+        };
+      });
+
+      return {
+        ...page,
+        components: updatedComponents,
+      };
+    });
+
+    this.pagesSubject.next(pages);
+    this.touchProject();
+  }
+
+  moveComponent(componentId: string, position: LayoutDimensions): void {
+    this.updateComponent(componentId, { position });
+  }
+
+  selectComponent(componentId: string | null): void {
+    this.selectedComponentIdSubject.next(componentId);
+  }
+
+  setActivePage(pageId: string): void {
+    if (this.activePageIdSubject.value === pageId) {
+      return;
+    }
+
+    this.activePageIdSubject.next(pageId);
+    const activePage = this.pagesSubject.value.find(page => page.id === pageId);
+    this.selectedComponentIdSubject.next(activePage?.components[0]?.id ?? null);
+  }
+
+  addPage(): void {
+    const page: DashboardPage = {
+      id: createId('page'),
+      name: `Página ${this.pagesSubject.value.length + 1}`,
+      components: [],
+    };
+
+    this.pagesSubject.next([...this.pagesSubject.value, page]);
+    this.setActivePage(page.id);
+    this.touchProject();
+  }
+
+  renamePage(pageId: string, name: string): void {
+    this.pagesSubject.next(
+      this.pagesSubject.value.map(page => (page.id === pageId ? { ...page, name } : page)),
+    );
+    this.touchProject();
+  }
+
+  duplicatePage(pageId: string): void {
+    const sourcePage = this.pagesSubject.value.find(page => page.id === pageId);
+    if (!sourcePage) {
+      return;
+    }
+
+    const clone: DashboardPage = {
+      id: createId('page'),
+      name: `${sourcePage.name} (cópia)`,
+      components: sourcePage.components.map(component => ({
+        ...component,
+        id: createId('component'),
+        position: { ...component.position, y: component.position.y + 32 },
+      })),
+    };
+
+    this.pagesSubject.next([...this.pagesSubject.value, clone]);
+    this.setActivePage(clone.id);
+    this.touchProject();
+  }
+
+  updateProjectStatus(status: DashboardProject['status']): void {
+    this.projectSubject.next({
+      ...this.projectSubject.value,
+      status,
+      lastUpdated: new Date().toISOString(),
+    });
+  }
+
+  upsertDataSource(dataSource: DataSource): void {
+    const existingIndex = this.dataSourcesSubject.value.findIndex(item => item.id === dataSource.id);
+    if (existingIndex === -1) {
+      this.dataSourcesSubject.next([...this.dataSourcesSubject.value, dataSource]);
+    } else {
+      const updated = [...this.dataSourcesSubject.value];
+      updated[existingIndex] = dataSource;
+      this.dataSourcesSubject.next(updated);
+    }
+  }
+
+  createDataSource(partial: Omit<DataSource, 'id' | 'lastUpdate'> & { lastUpdate?: string }): DataSource {
+    const dataSource: DataSource = {
+      ...partial,
+      id: createId('ds'),
+      lastUpdate: partial.lastUpdate ?? new Date().toISOString(),
+    };
+
+    this.upsertDataSource(dataSource);
+    return dataSource;
+  }
+
+  removeDataSource(dataSourceId: string): void {
+    this.dataSourcesSubject.next(
+      this.dataSourcesSubject.value.filter(item => item.id !== dataSourceId),
+    );
+  }
+
+  private createComponentFromTemplate(
+    template: ComponentTemplate,
+    page: DashboardPage,
+  ): DashboardComponentModel {
+    const defaultDataSourceId = this.dataSourcesSubject.value[0]?.id;
+    const gridColumn = page.components.length % 2;
+    const gridRow = Math.floor(page.components.length / 2);
+
+    return {
+      id: createId('component'),
+      templateId: template.id,
+      title: template.name,
+      type: template.type,
+      position: {
+        x: 32 + gridColumn * (template.defaultSize.width + 32),
+        y: 32 + gridRow * (template.defaultSize.height + 24),
+        width: template.defaultSize.width,
+        height: template.defaultSize.height,
+      },
+      data: {
+        dataSourceId: template.defaultData?.dataSourceId ?? defaultDataSourceId,
+        metric: template.defaultData?.metric ?? '',
+        dimension: template.defaultData?.dimension ?? '',
+        comparisonMetric: template.defaultData?.comparisonMetric ?? '',
+        filters: template.defaultData?.filters ?? [],
+      },
+      style: {
+        backgroundColor: '#ffffff',
+        accentColor: '#2ec4b6',
+        textColor: '#0d1b2a',
+        showBorder: false,
+        cornerRadius: 12,
+      },
+    };
+  }
+
+  private touchProject(): void {
+    this.projectSubject.next({
+      ...this.projectSubject.value,
+      lastUpdated: new Date().toISOString(),
+    });
+  }
+
+  private buildInitialPages(): DashboardPage[] {
+    const componentKpi: DashboardComponentModel = {
+      id: createId('component'),
+      templateId: 'kpi-principal',
+      title: 'Receita Mensal',
+      type: 'kpi',
+      position: { x: 32, y: 32, width: 280, height: 160 },
+      data: {
+        dataSourceId: 'ds-financeiro',
+        metric: 'receita_total',
+        comparisonMetric: 'receita_total_anterior',
+      },
+      style: {
+        backgroundColor: '#ffffff',
+        accentColor: '#2ec4b6',
+        textColor: '#0d1b2a',
+        showBorder: false,
+        cornerRadius: 12,
+      },
+    };
+
+    const componentGrafico: DashboardComponentModel = {
+      id: createId('component'),
+      templateId: 'grafico-linhas',
+      title: 'Evolução de Vendas',
+      type: 'linha',
+      position: { x: 344, y: 32, width: 560, height: 320 },
+      data: {
+        dataSourceId: 'ds-financeiro',
+        metric: 'receita_total',
+        dimension: 'mes',
+      },
+      style: {
+        backgroundColor: '#ffffff',
+        accentColor: '#2ec4b6',
+        textColor: '#0d1b2a',
+        showBorder: false,
+        cornerRadius: 12,
+      },
+    };
+
+    const componentTabela: DashboardComponentModel = {
+      id: createId('component'),
+      templateId: 'tabela-desempenho',
+      title: 'Top Clientes',
+      type: 'tabela',
+      position: { x: 32, y: 216, width: 280, height: 320 },
+      data: {
+        dataSourceId: 'ds-crm',
+        metric: 'valor_total',
+        dimension: 'cliente',
+      },
+      style: {
+        backgroundColor: '#ffffff',
+        accentColor: '#2ec4b6',
+        textColor: '#0d1b2a',
+        showBorder: true,
+        cornerRadius: 12,
+      },
+    };
+
+    return [
+      {
+        id: createId('page'),
+        name: 'Visão Geral',
+        components: [componentKpi, componentGrafico, componentTabela],
+      },
+    ];
+  }
+
+  private buildInitialDataSources(): DataSource[] {
+    return [
+      {
+        id: 'ds-financeiro',
+        name: 'ERP - Financeiro',
+        type: 'sankhya',
+        status: 'conectado',
+        refresh: 'agendado',
+        lastUpdate: new Date().toISOString(),
+        owner: 'Equipe Financeira',
+        description: 'Dados consolidados do módulo financeiro atualizados diariamente.',
+      },
+      {
+        id: 'ds-crm',
+        name: 'CRM - Vendas',
+        type: 'rest',
+        status: 'conectado',
+        refresh: 'tempo-real',
+        lastUpdate: new Date().toISOString(),
+        owner: 'Time Comercial',
+        description: 'Integração REST com oportunidades e clientes.',
+      },
+    ];
+  }
+}

--- a/src/app/utils/id.ts
+++ b/src/app/utils/id.ts
@@ -1,0 +1,5 @@
+export function createId(prefix: string): string {
+  const random = Math.random().toString(36).substring(2, 8);
+  const timestamp = Date.now().toString(36);
+  return `${prefix}-${timestamp}-${random}`;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="pt-br">
+  <head>
+    <meta charset="utf-8" />
+    <title>Dashboard Builder</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,7 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,0 +1,63 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0');
+
+:root {
+  --color-navy: #0d1b2a;
+  --color-navy-strong: #1b263b;
+  --color-teal: #2ec4b6;
+  --color-warning: #ff9f1c;
+  --color-surface: #f5f7fa;
+  --color-border: #e0e6ed;
+  --color-text: #1b263b;
+  --color-muted: #74828f;
+  --radius-lg: 12px;
+  --radius-md: 8px;
+  --shadow-card: 0 4px 16px rgba(13, 27, 42, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Montserrat', Arial, sans-serif;
+  color: var(--color-text);
+  background: var(--color-surface);
+  min-height: 100%;
+}
+
+body {
+  display: flex;
+}
+
+app-root {
+  flex: 1 1 auto;
+  display: flex;
+}
+
+button {
+  font-family: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.material-symbols-outlined {
+  font-family: 'Material Symbols Outlined';
+  font-weight: 400;
+  font-style: normal;
+  font-size: 20px;
+  line-height: 1;
+  letter-spacing: normal;
+  display: inline-flex;
+  vertical-align: middle;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+  -webkit-font-smoothing: antialiased;
+}

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,8 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*.d.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "module": "es2022",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "lib": ["es2022", "dom"]
+  }
+}

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": ["jasmine"]
+  },
+  "files": ["src/test.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary
- add a preview overlay component that opens from the header and renders the active dashboard page with device toggles
- surface page switching, data source context and responsive canvas styling inside the immersive preview experience
- document the new preview overlay feature in the README and functional specification

## Testing
- npm install *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68cf229ec8ec83339521db900d4a58f5